### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe HTML constructed from library input

### DIFF
--- a/Travel Planner - SE Project/wwwroot/lib/jquery/dist/jquery.js
+++ b/Travel Planner - SE Project/wwwroot/lib/jquery/dist/jquery.js
@@ -1275,10 +1275,21 @@ function setDocument( node ) {
 
 		var input;
 
-		documentElement.appendChild( el ).innerHTML =
-			"<a id='" + expando + "' href='' disabled='disabled'></a>" +
-			"<select id='" + expando + "-\r\\' disabled='disabled'>" +
-			"<option selected=''></option></select>";
+		var anchor = document.createElement('a');
+		anchor.id = expando;
+		anchor.href = '';
+		anchor.disabled = true;
+		el.appendChild(anchor);
+
+		var select = document.createElement('select');
+		select.id = expando + "-\r\\";
+		select.disabled = true;
+
+		var option = document.createElement('option');
+		option.selected = true;
+		select.appendChild(option);
+
+		el.appendChild(select);
 
 		// Support: iOS <=7 - 8 only
 		// Boolean attributes and "value" are not treated correctly in some XML documents


### PR DESCRIPTION
Potential fix for [https://github.com/AlecuDaniel/Travel-Planner---SE-Project/security/code-scanning/3](https://github.com/AlecuDaniel/Travel-Planner---SE-Project/security/code-scanning/3)

To fix the problem, we need to ensure that the HTML construction using the `innerHTML` property is safe. This can be achieved by using safer methods to manipulate the DOM, such as creating elements and setting their properties directly, rather than constructing HTML strings. Specifically, we should replace the use of `innerHTML` with methods that do not involve parsing HTML strings.

- Replace the `innerHTML` assignment with the creation of elements using `document.createElement` and setting their attributes and properties directly.
- Ensure that any dynamic content is properly escaped or sanitized before being used in the DOM.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
